### PR TITLE
Removed scientific notation in model.sdf file IMU settings

### DIFF
--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -518,30 +518,32 @@
             <x>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>8.72664e-5</stddev>
-                <bias_mean>7.5e-6</bias_mean>
-                <bias_stddev>8.0e-7</bias_stddev>
-                <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                 <stddev>0.0000872664</stddev>
+                 <bias_mean>0.0000075</bias_mean>
+                 <bias_stddev>0.00000080</bias_stddev>
+                 <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
+                 <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>8.72664e-5</stddev>
-                <bias_mean>7.5e-6</bias_mean>
-                <bias_stddev>8.0e-7</bias_stddev>
-                <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
+                 <stddev>0.0000872664</stddev>
+                 <bias_mean>0.0000075</bias_mean>
+                 <bias_stddev>0.00000080</bias_stddev>
+                 <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
+                 <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
                 <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
               </noise>
             </y>
             <z>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>8.72664e-5</stddev>
-                <bias_mean>7.5e-6</bias_mean>
-                <bias_stddev>8.0e-7</bias_stddev>
-                <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
+                 <stddev>0.0000872664</stddev>
+                 <bias_mean>0.0000075</bias_mean>
+                 <bias_stddev>0.00000080</bias_stddev>
+                 <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
+                 <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
                 <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
               </noise>
             </z>
@@ -550,30 +552,30 @@
             <x>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>1.962e-4</stddev>
-                <bias_mean>1.0e-3</bias_mean>
-                <bias_stddev>1.0-4</bias_stddev>
-                <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+                 <stddev>0.0001962</stddev>
+                 <bias_mean>0.001</bias_mean>
+                 <bias_stddev>0.0001</bias_stddev>
+                 <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
                 <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>1.962e-4</stddev>
-                <bias_mean>1.0e-3</bias_mean>
-                <bias_stddev>1.0-4</bias_stddev>
-                <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+                 <stddev>0.0001962</stddev>
+                 <bias_mean>0.001</bias_mean>
+                 <bias_stddev>0.0001</bias_stddev>
+                 <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
                 <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
               </noise>
             </y>
             <z>
               <noise type="gaussian">
                 <mean>0</mean>
-                <stddev>1.962e-4</stddev>
-                <bias_mean>1.0e-3</bias_mean>
-                <bias_stddev>1.0-4</bias_stddev>
-                <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+                 <stddev>0.0001962</stddev>
+                 <bias_mean>0.001</bias_mean>
+                 <bias_stddev>0.0001</bias_stddev>
+                 <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
                 <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
               </noise>
             </z>


### PR DESCRIPTION
Remove scientific notation of parameters in IMU settings in model.sdf (causes strange values from IMU is scientific notation is used).  This is for marble hd2 sensor config 1